### PR TITLE
#5 Add support for matching patterns along the string

### DIFF
--- a/src/commands/any-location/match.js
+++ b/src/commands/any-location/match.js
@@ -1,0 +1,46 @@
+import {specialCharacters} from '../commands';
+import {exactCount} from './../../snippets/ranges';
+
+function match(input, count) {
+	count = (isNaN(count)) ? '' : exactCount(count);
+	return `${input}${count}`;
+}
+
+function matchAnyOfThese(input) {
+	return `[${input}]`;
+}
+
+function maybe(input) {
+	return input + '?';
+}
+
+export default [
+	[
+		() => '^',
+		/^start of string/
+	],
+	[
+		() => '$',
+		/^end of string/
+	],
+	[
+		match,
+		/^match: (.*)$/
+	],
+	[
+		(count, type) => match(specialCharacters[type], count),
+		/^match (\d+) ([a-z ]+?)s?$/
+	],
+	[
+		matchAnyOfThese,
+		/^match any of these: (.*?)$/
+	],
+	[
+		maybe,
+		/^maybe: (.*?)$/
+	],
+	[
+		(count, type) => match(specialCharacters[type], count),
+		/^maybe (\d+) ([a-z ]+?)s?$/
+	]
+];

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,5 +1,6 @@
 import lengths from './full-string-assertions/lengths';
 import contains from './full-string-assertions/contains';
+import match from './any-location/match';
 
 export let specialCharacters = {
 	'number': `\\d`,
@@ -21,7 +22,7 @@ function registerRule(callback, ...regexes) {
 	});
 }
 
-[...lengths, ...contains]
+[...lengths, ...contains, ...match]
 	.forEach(rule => {
 		registerRule(...rule);
 	});

--- a/src/snippets/ranges.js
+++ b/src/snippets/ranges.js
@@ -1,0 +1,3 @@
+export function exactCount(count) {
+	return `{${count}}`;
+}


### PR DESCRIPTION
Adds the following commands:
```
start of string
maybe 1 letter
maybe: +
match: 1-
match any of these: -,.
match 3 digits
end of string
```
Related Issue: #5 