### PR TITLE
#6 Support capturing groups

### DIFF
--- a/src/commands/any-location/capture.js
+++ b/src/commands/any-location/capture.js
@@ -1,0 +1,19 @@
+import regexBuilder from '../../regexBuilder';
+import {regexToString} from '../../utils';
+
+export default [
+	[
+		function (captureName, command) {
+			const regex = regexToString(regexBuilder(command));
+			this.captureMap[captureName] = ++this.captureCount;
+			return `(${regex})`;
+		},
+		/as ([a-z]+),? (.*)$/,
+	],
+	[
+		function (captureName) {
+			return `\\${this.captureMap[captureName]}`;
+		},
+		/match capture ([a-z]+)/,
+	],
+];

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,6 +1,7 @@
 import lengths from './full-string-assertions/lengths';
 import contains from './full-string-assertions/contains';
 import match from './any-location/match';
+import capture from './any-location/capture';
 
 export let specialCharacters = {
 	'number': '\\d',
@@ -22,7 +23,7 @@ function registerRule(callback, ...regexes) {
 	});
 }
 
-[...lengths, ...contains, ...match]
+[...lengths, ...contains, ...match, ...capture]
 	.forEach(rule => {
 		registerRule(...rule);
 	});

--- a/src/regexBuilder.js
+++ b/src/regexBuilder.js
@@ -19,7 +19,8 @@ export default function builder(words) {
 			let m = line.match(lock[i]);
 			if (m) {
 				understood = true;
-				regex.push(rules[i].callback(...m.splice(1).map(escapeRegex)));
+				// "this" is the instance of RegularWords
+				regex.push(rules[i].callback.call(this, ...m.splice(1).map(escapeRegex)));
 				break;
 			}
 		}

--- a/src/regular-words.js
+++ b/src/regular-words.js
@@ -4,7 +4,9 @@ import regexBuilder from './regexBuilder';
 class RegularWords {
 	constructor(words) {
 		this.words = words;
-		this.regex = regexBuilder(words);
+		this.captureCount = 0;
+		this.captureMap = {};
+		this.regex = regexBuilder.call(this, words);
 	}
 
 	test(string) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,7 @@
 export function escapeRegex(s) {
 	return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
+
+export function regexToString(regex) {
+	return regex.toString().replace(/^\/(.*)\/$/, '$1');
+}


### PR DESCRIPTION
Command:
```
as captureName match any of these: -,.
match capture captureName
```
where `captureName` can be named whatever you want.

Any normal command can be used after the `as captureName` statement.

Closes #6 